### PR TITLE
Frontend optimisation

### DIFF
--- a/frontend/src/disktree.ts
+++ b/frontend/src/disktree.ts
@@ -209,7 +209,7 @@ const phi = (1 + Math.sqrt(5)) / 2,
 		}
 
 		return svg({ "class": "treeMap", "width": width + "", "height": height + "", "viewBox": `0 0 ${width} ${height}`, "mouseout": onmouseout ?? (() => { }) },
-			buildTree(table, box)
+			buildTree(filteredTable, box)
 		)
 	},
 	secondsInSevenYears = 7 * 365 * 86400,

--- a/frontend/src/list.ts
+++ b/frontend/src/list.ts
@@ -3,7 +3,8 @@ import { clearNode } from './lib/dom.js';
 import { table, tbody, td, th, thead, tr } from './lib/html.js';
 import { formatBytes } from './lib/utils.js';
 
-const base = tbody();
+const base = tbody(),
+	dateFormat = new Intl.DateTimeFormat('en-GB', { timeZone: 'Europe/London', year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', second: '2-digit' });
 
 export default Object.assign(table({ "class": "prettyTable", "id": "dirlist" }, [
 	thead(tr([th("SubDirectory"), th("File Size"), th("File Count"), th("Last Modified")])),
@@ -14,7 +15,7 @@ export default Object.assign(table({ "class": "prettyTable", "id": "dirlist" }, 
 			td(name),
 			td({ "title": child.size.toLocaleString() }, formatBytes(child.size)),
 			td(child.count.toLocaleString()),
-			td(new Date(child.mtime * 1000).toLocaleString('en-GB', { timeZone: 'Europe/London', year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', second: '2-digit' }))
+			td(dateFormat.format(new Date(child.mtime * 1000)))
 		])
 	}))
 });


### PR DESCRIPTION
Two minor optimisations for directories with many children.

- Limit DiskTree to top 1000 children (was already implemented, but not used).
- Use a constant formatter for the Listing Date as it's faster than recreating for each child.