### PR TITLE
Improve RAM usage of StateMachine

### DIFF
--- a/backups/backups.go
+++ b/backups/backups.go
@@ -31,7 +31,7 @@ func Backup(planDB *db.DB, treeNode tree.Node, client *ibackup.MultiClient) ([]S
 		return nil, err
 	}
 
-	dirs, rules, err := readDirRules(planDB, mountpoint)
+	dirs, dirRules, err := readDirRules(planDB, mountpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -45,17 +45,19 @@ func Backup(planDB *db.DB, treeNode tree.Node, client *ibackup.MultiClient) ([]S
 	root.Canon()
 	root.MarkBackupDirs()
 
-	groups := collectRuleGroups(root, "/", nil)
+	rules := root.BuildRules()
 
-	sm, err := group.NewStatemachine(groups)
+	rules[0] = collectRuleGroups(root, "/", rules[0])
+
+	sm, err := ruletree.BuildMultiStateMachine(rules)
 	if err != nil {
 		return nil, err
 	}
 
 	setFofns := make(map[*db.Directory][]string)
 
-	figureOutFOFNs(treeNode, sm.GetStateString(""), nil, func(path *summary.DirectoryPath, ruleID int64) {
-		rule := rules[ruleID]
+	figureOutFOFNs(treeNode, sm, nil, func(path *summary.DirectoryPath, ruleID int64) {
+		rule := dirRules[ruleID]
 
 		if rule.RuleIDs[ruleID].BackupType == db.BackupIBackup {
 			setFofns[rule.Directory] = append(setFofns[rule.Directory], string(path.AppendTo(nil)))
@@ -142,15 +144,6 @@ func collectRuleGroups(root *ruletree.RuleTree, path string, rules ruletree.Rule
 		})
 	}
 
-	for _, rule := range root.Rules {
-		id := rule.ID()
-
-		rules = append(rules, group.PathGroup[int64]{
-			Path:  []byte(path + rule.Match),
-			Group: &id,
-		})
-	}
-
 	for name, rt := range root.Iter() {
 		rules = collectRuleGroups(rt, path+name, rules)
 	}
@@ -158,7 +151,7 @@ func collectRuleGroups(root *ruletree.RuleTree, path string, rules ruletree.Rule
 	return rules
 }
 
-func figureOutFOFNs(node tree.Node, sm group.State[int64], path *summary.DirectoryPath,
+func figureOutFOFNs(node tree.Node, sm ruletree.State, path *summary.DirectoryPath,
 	cb func(*summary.DirectoryPath, int64)) {
 	for name, child := range node.Children() {
 		state := sm.GetStateString(name)

--- a/backups/backups_test.go
+++ b/backups/backups_test.go
@@ -28,8 +28,8 @@ func TestFileInfos(t *testing.T) {
 
 		var paths []string
 
-		sm, err := group.NewStatemachine(ruletree.Rules{
-			{Path: []byte("*"), Group: &hasBackups},
+		sm, err := ruletree.BuildMultiStateMachine([]ruletree.Rules{
+			{{Path: []byte("*"), Group: &hasBackups}},
 		})
 		So(err, ShouldBeNil)
 
@@ -40,7 +40,7 @@ func TestFileInfos(t *testing.T) {
 			So(err, ShouldBeNil)
 		}
 
-		figureOutFOFNs(ctr, sm.GetStateString("/lustre/scratch123/humgen/a/b/"),
+		figureOutFOFNs(ctr, sm,
 			&summary.DirectoryPath{Name: "/lustre/scratch123/humgen/a/b/"}, func(path *summary.DirectoryPath, _ int64) {
 				paths = append(paths, string(path.AppendTo(nil)))
 			})
@@ -122,26 +122,29 @@ func TestCreateRuleGroups(t *testing.T) {
 		root.Canon()
 		root.MarkBackupDirs()
 
-		rgs := collectRuleGroups(root, "/", nil)
+		rules := root.BuildRules()
 
-		So(len(rgs), ShouldEqual, 9)
+		rules[0] = collectRuleGroups(root, "/", rules[0])
+
+		So(len(rules), ShouldEqual, 1)
+		So(len(rules[0]), ShouldEqual, 10)
 		So(len(ruleList), ShouldEqual, 3)
-
-		var rules []*db.Rule
 
 		readRules := testDB.ReadRules()
 
+		var dbRules []*db.Rule
+
 		readRules.ForEach(func(rule *db.Rule) error { //nolint:errcheck
-			rules = append(rules, rule)
+			dbRules = append(dbRules, rule)
 
 			return nil
 		})
 
-		slices.SortFunc(rgs, func(a, b group.PathGroup[int64]) int {
+		slices.SortFunc(rules[0], func(a, b group.PathGroup[int64]) int {
 			return bytes.Compare(a.Path, b.Path)
 		})
 
-		So(rgs, ShouldResemble, ruletree.Rules{
+		So(rules[0], ShouldResemble, ruletree.Rules{
 			{
 				Path:  []byte("/"),
 				Group: &hasBackups,
@@ -167,16 +170,20 @@ func TestCreateRuleGroups(t *testing.T) {
 				Group: &hasBackups,
 			},
 			{
-				Path:  []byte("/lustre/scratch123/humgen/a/b/" + rules[0].Match),
-				Group: ptr(rules[0].ID()),
+				Path:  []byte("/lustre/scratch123/humgen/a/b/" + dbRules[0].Match),
+				Group: ptr(dbRules[0].ID()),
 			},
 			{
 				Path:  []byte("/lustre/scratch123/humgen/a/b/*/"),
 				Group: &hasBackups,
 			},
 			{
-				Path:  []byte("/lustre/scratch123/humgen/a/b/" + rules[1].Match),
-				Group: ptr(rules[1].ID()),
+				Path:  []byte("/lustre/scratch123/humgen/a/b/" + dbRules[1].Match),
+				Group: ptr(dbRules[1].ID()),
+			},
+			{
+				Path:  []byte("/lustre/scratch123/humgen/a/c/" + dbRules[2].Match),
+				Group: ptr(dbRules[2].ID()),
 			},
 		})
 	})

--- a/ruletree/ruletree.go
+++ b/ruletree/ruletree.go
@@ -32,7 +32,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/wtsi-hgi/wrstat-ui/summary/group"
 	"vimagination.zapto.org/byteio"
 	"vimagination.zapto.org/tree"
 )
@@ -146,7 +145,7 @@ func (f *file) readFrom(lr byteio.MemLittleEndian) {
 //		directory ID to get the wildcard ID.
 type ruleProcessor struct {
 	lowerNode, upperNode *tree.MemTree
-	sm                   group.State[int64]
+	sm                   State
 	UID, GID             uint32
 	Rules                []Rule
 }
@@ -223,7 +222,7 @@ func (r *ruleProcessor) getRulePos(ruleID int64) int {
 	return pos
 }
 
-func (r *ruleProcessor) processDir(name string, state group.State[int64],
+func (r *ruleProcessor) processDir(name string, state State,
 	lowerChild, upperChild *tree.MemTree, yield func(string, tree.Node) bool) bool {
 	childProcessor := ruleProcessor{
 		lowerNode: lowerChild,

--- a/ruletree/statemachine.go
+++ b/ruletree/statemachine.go
@@ -1,3 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Genome Research Ltd.
+ *
+ * Author: Michael Woolnough <mw31@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
 package ruletree
 
 import (
@@ -429,6 +454,12 @@ func (r *RuleTree) BuildRules() []Rules {
 }
 
 func factorial(n int) int {
+	const maxFactorial = 10
+
+	if n > maxFactorial {
+		return math.MaxInt
+	}
+
 	r := 1
 
 	for i := range n {

--- a/ruletree/statemachine.go
+++ b/ruletree/statemachine.go
@@ -423,7 +423,7 @@ func (r *RuleTree) buildChildRules(path string, rules []Rules) ([]Rules, bool) {
 
 func (r *RuleTree) hasComplexRules() bool {
 	for match := range r.Rules {
-		if strings.Count(match, "*") > 1 {
+		if strings.Count(match, "*") > 2 {
 			return true
 		}
 	}
@@ -432,10 +432,6 @@ func (r *RuleTree) hasComplexRules() bool {
 }
 
 func (r *RuleTree) processRules(path string, rules []Rules, hasVeryComplex, childHasVeryComplex bool) []Rules {
-	if len(r.Rules) == 0 {
-		return rules
-	}
-
 	var idx int
 
 	if childHasVeryComplex && !hasVeryComplex {

--- a/ruletree/statemachine.go
+++ b/ruletree/statemachine.go
@@ -396,6 +396,14 @@ func (r *RuleTree) Iter() iter.Seq2[string, *RuleTree] {
 
 var star = []byte{'*'} //nolint:gochecknoglobals
 
+// BuildRules generates a slice of Rule sets from the current RuleTree.
+//
+// The sets are split based on a scoring mechanism that intends to stop the
+// StateMachine sizes becoming unwieldy, but while not significantly increasing
+// the runtime of the rule engine.
+//
+// The returned slice of Rules should be given to BuildMultiStateMachine to
+// build the combined statemachine.
 func (r *RuleTree) BuildRules() []Rules {
 	const maxScore = 1 << 24
 

--- a/ruletree/statemachine.go
+++ b/ruletree/statemachine.go
@@ -1,6 +1,7 @@
 package ruletree
 
 import (
+	"bytes"
 	"iter"
 	"maps"
 	"math"
@@ -393,19 +394,40 @@ func (r *RuleTree) Iter() iter.Seq2[string, *RuleTree] {
 	return maps.All(r.children)
 }
 
+var star = []byte{'*'} //nolint:gochecknoglobals
+
 func (r *RuleTree) BuildRules() []Rules {
+	const maxScore = 1 << 24
+
 	rules, _ := r.buildRules("/", []Rules{nil}, 1)
 	prules := []Rules{rules[0]}
+	score := maxScore + 1
 
 	for _, ruleList := range slices.Backward(rules[1:]) {
-		if len(ruleList) == 0 {
-			continue
-		}
+		for _, rule := range ruleList {
+			starScore := factorial(bytes.Count(rule.Path, star))
+			if nScore := score * starScore; nScore > maxScore {
+				prules = append(prules, nil)
+				score = starScore
+			} else {
+				score = nScore
+			}
 
-		prules = append(prules, ruleList)
+			prules[len(prules)-1] = append(prules[len(prules)-1], rule)
+		}
 	}
 
 	return prules
+}
+
+func factorial(n int) int {
+	r := 1
+
+	for i := range n {
+		r *= (i + 1)
+	}
+
+	return r
 }
 
 func (r *RuleTree) buildRules(path string, rules []Rules, depth int) ([]Rules, bool) {
@@ -454,11 +476,54 @@ func (r *RuleTree) processRules(path string, rules []Rules, hasVeryComplex bool,
 		}
 	}
 
-	for match, rule := range r.Rules {
+	for match, rule := range orderRulesByPrecedence(r.Rules) {
 		rules[idx] = addRuleToList(rules[idx], path+match, rule.ID())
 	}
 
 	return rules
+}
+
+func orderRulesByPrecedence(rules map[string]*db.Rule) iter.Seq2[string, *db.Rule] {
+	return func(yield func(string, *db.Rule) bool) {
+		keys := slices.Collect(maps.Keys(rules))
+
+		slices.SortFunc(keys, matchPrecedence)
+
+		for _, key := range keys {
+			if !yield(key, rules[key]) {
+				return
+			}
+		}
+	}
+}
+
+func matchPrecedence(a, b string) int { //nolint:gocognit,gocyclo
+	if len(a) == 0 { //nolint:nestif
+		if len(b) == 0 {
+			return 0
+		}
+
+		return 1
+	} else if len(b) == 0 {
+		return -1
+	}
+
+	aPos := strings.IndexByte(a, '*')
+	bPos := strings.IndexByte(b, '*')
+
+	if aPos == -1 { //nolint:gocritic,nestif
+		if bPos == -1 {
+			return len(b) - len(a)
+		}
+
+		return -1
+	} else if bPos == -1 {
+		return 1
+	} else if a[:aPos] == b[:bPos] {
+		return matchPrecedence(a[aPos+1:], b[bPos+1:])
+	}
+
+	return bPos - aPos
 }
 
 func (r *RuleTree) addRuleStates(path string, rules Rules, wildcard int64) Rules { //nolint:gocyclo

--- a/ruletree/statemachine.go
+++ b/ruletree/statemachine.go
@@ -12,7 +12,10 @@ import (
 	"github.com/wtsi-hgi/wrstat-ui/summary/group"
 )
 
-const processRules int64 = math.MinInt64
+const (
+	processRules          int64 = math.MinInt64
+	maxWildcardsForSimple       = 2
+)
 
 var noMatchingRules = new(int64) //nolint:gochecknoglobals
 
@@ -423,7 +426,7 @@ func (r *RuleTree) buildChildRules(path string, rules []Rules) ([]Rules, bool) {
 
 func (r *RuleTree) hasComplexRules() bool {
 	for match := range r.Rules {
-		if strings.Count(match, "*") > 2 {
+		if strings.Count(match, "*") > maxWildcardsForSimple {
 			return true
 		}
 	}

--- a/ruletree/statemachine.go
+++ b/ruletree/statemachine.go
@@ -394,28 +394,37 @@ func (r *RuleTree) Iter() iter.Seq2[string, *RuleTree] {
 }
 
 func (r *RuleTree) BuildRules() []Rules {
-	rules, _ := r.buildRules("/", []Rules{nil})
+	rules, _ := r.buildRules("/", []Rules{nil}, 1)
+	prules := []Rules{rules[0]}
 
-	return rules
+	for _, ruleList := range slices.Backward(rules[1:]) {
+		if len(ruleList) == 0 {
+			continue
+		}
+
+		prules = append(prules, ruleList)
+	}
+
+	return prules
 }
 
-func (r *RuleTree) buildRules(path string, rules []Rules) ([]Rules, bool) {
+func (r *RuleTree) buildRules(path string, rules []Rules, depth int) ([]Rules, bool) {
 	var childHasVeryComplex bool
 
-	rules, childHasVeryComplex = r.buildChildRules(path, rules)
-	hasVeryComplex := r.hasComplexRules()
-	rules = r.processRules(path, rules, hasVeryComplex, childHasVeryComplex)
+	rules, childHasVeryComplex = r.buildChildRules(path, rules, depth+1)
+	hasVeryComplex := childHasVeryComplex || r.hasComplexRules()
+	rules = r.processRules(path, rules, hasVeryComplex, depth)
 
-	return rules, hasVeryComplex || childHasVeryComplex
+	return rules, hasVeryComplex
 }
 
-func (r *RuleTree) buildChildRules(path string, rules []Rules) ([]Rules, bool) {
+func (r *RuleTree) buildChildRules(path string, rules []Rules, depth int) ([]Rules, bool) {
 	var childHasVeryComplex bool
 
 	for part, child := range r.children {
 		var complexChild bool
 
-		rules, complexChild = child.buildRules(path+part, rules)
+		rules, complexChild = child.buildRules(path+part, rules, depth)
 		if complexChild {
 			childHasVeryComplex = true
 		}
@@ -434,20 +443,19 @@ func (r *RuleTree) hasComplexRules() bool {
 	return false
 }
 
-func (r *RuleTree) processRules(path string, rules []Rules, hasVeryComplex, childHasVeryComplex bool) []Rules {
+func (r *RuleTree) processRules(path string, rules []Rules, hasVeryComplex bool, depth int) []Rules {
 	var idx int
 
-	if childHasVeryComplex && !hasVeryComplex {
-		idx = len(rules)
-		rules = append(rules, nil)
+	if hasVeryComplex {
+		idx = depth
+
+		if len(rules) <= idx {
+			rules = slices.Grow(rules, idx-len(rules)+1)[:idx+1]
+		}
 	}
 
-	for match, rule := range orderRulesByPrecedence(r.Rules) {
-		if hasVeryComplex {
-			rules = append(rules, addRuleToList(nil, path+match, rule.ID()))
-		} else {
-			rules[idx] = addRuleToList(rules[idx], path+match, rule.ID())
-		}
+	for match, rule := range r.Rules {
+		rules[idx] = addRuleToList(rules[idx], path+match, rule.ID())
 	}
 
 	return rules
@@ -507,49 +515,6 @@ func buildDirRules(mount string, paths []string,
 	rules[0] = root.addRuleStates("/", rules[0], 0)
 
 	return rules, buildWildcards(root, "/", nil)
-}
-
-func orderRulesByPrecedence(rules map[string]*db.Rule) iter.Seq2[string, *db.Rule] {
-	return func(yield func(string, *db.Rule) bool) {
-		keys := slices.Collect(maps.Keys(rules))
-
-		slices.SortFunc(keys, matchPrecedence)
-
-		for _, key := range keys {
-			if !yield(key, rules[key]) {
-				return
-			}
-		}
-	}
-}
-
-func matchPrecedence(a, b string) int { //nolint:gocognit,gocyclo
-	if len(a) == 0 { //nolint:nestif
-		if len(b) == 0 {
-			return 0
-		}
-
-		return 1
-	} else if len(b) == 0 {
-		return -1
-	}
-
-	aPos := strings.IndexByte(a, '*')
-	bPos := strings.IndexByte(b, '*')
-
-	if aPos == -1 { //nolint:gocritic,nestif
-		if bPos == -1 {
-			return len(b) - len(a)
-		}
-
-		return -1
-	} else if bPos == -1 {
-		return 1
-	} else if a[:aPos] == b[:bPos] {
-		return matchPrecedence(a[aPos+1:], b[bPos+1:])
-	}
-
-	return bPos - aPos
 }
 
 func getRuleState(rules map[string]*db.Rule) ruleState { //nolint:gocognit

--- a/ruletree/statemachine.go
+++ b/ruletree/statemachine.go
@@ -14,12 +14,20 @@ import (
 
 const processRules int64 = math.MinInt64
 
-var noMatchingRules = new(int64)
+var noMatchingRules = new(int64) //nolint:gochecknoglobals
 
+// State represents a partial match that can be continued or completed.
 type State struct {
 	groups []group.State[int64]
 }
 
+// BuildMultiStateMachine take a slice of rulesets and builds a statemachine for
+// each.
+//
+// State returns handles like group.State, but iterates over each individual
+// StateMachine, removing those that no longer apply.
+//
+// The slice should be ordered by precedence, with the highest first.
 func BuildMultiStateMachine(rules []Rules) (State, error) {
 	groups := make([]group.State[int64], len(rules))
 
@@ -44,6 +52,8 @@ func setDefaultGroup(sm group.StateMachine[int64]) {
 	})(unsafe.Pointer(&sm[0])).Group = noMatchingRules
 }
 
+// GetState continues matching with the given match string, returning a new
+// State.
 func (s State) GetStateString(match string) State {
 	gs := make([]group.State[int64], 0, len(s.groups))
 
@@ -56,6 +66,9 @@ func (s State) GetStateString(match string) State {
 	return State{groups: gs}
 }
 
+// GetGroup returns the group at the current state.
+//
+// When multiple statemachines exist, the first valid group is returned.
 func (s State) GetGroup() *int64 {
 	for _, g := range s.groups {
 		if r := g.GetGroup(); r != noMatchingRules && r != nil {
@@ -378,18 +391,18 @@ func (r *RuleTree) Iter() iter.Seq2[string, *RuleTree] {
 }
 
 func (r *RuleTree) BuildRules() []Rules {
-	rules, _ := r.buildRules("/", []Rules{nil}, 0)
+	rules, _ := r.buildRules("/", []Rules{nil})
 
 	return rules
 }
 
-func (r *RuleTree) buildRules(path string, rules []Rules, wildcard int64) ([]Rules, bool) { //nolint:gocyclo,cyclop,funlen
+func (r *RuleTree) buildRules(path string, rules []Rules) ([]Rules, bool) { //nolint:gocyclo,gocognit
 	var hasVeryComplex bool
 
 	for part, child := range r.children {
 		var childHasVeryComplex bool
 
-		rules, childHasVeryComplex = child.buildRules(path+part, rules, wildcard)
+		rules, childHasVeryComplex = child.buildRules(path+part, rules)
 		if childHasVeryComplex {
 			hasVeryComplex = true
 		}
@@ -416,7 +429,7 @@ func (r *RuleTree) buildRules(path string, rules []Rules, wildcard int64) ([]Rul
 	return rules, hasVeryComplex
 }
 
-func (r *RuleTree) addRuleStates(path string, rules Rules, wildcard int64) Rules {
+func (r *RuleTree) addRuleStates(path string, rules Rules, wildcard int64) Rules { //nolint:gocyclo
 	if wc, ok := r.Rules["*"]; ok {
 		wildcard = wc.ID()
 	}
@@ -486,8 +499,8 @@ func orderRulesByPrecedence(rules map[string]*db.Rule) iter.Seq2[string, *db.Rul
 	}
 }
 
-func matchPrecedence(a, b string) int {
-	if len(a) == 0 {
+func matchPrecedence(a, b string) int { //nolint:gocognit,gocyclo
+	if len(a) == 0 { //nolint:nestif
 		if len(b) == 0 {
 			return 0
 		}
@@ -500,7 +513,7 @@ func matchPrecedence(a, b string) int {
 	aPos := strings.IndexByte(a, '*')
 	bPos := strings.IndexByte(b, '*')
 
-	if aPos == -1 {
+	if aPos == -1 { //nolint:gocritic,nestif
 		if bPos == -1 {
 			return len(b) - len(a)
 		}

--- a/ruletree/statemachine.go
+++ b/ruletree/statemachine.go
@@ -29,15 +29,19 @@ func BuildMultiStateMachine(rules []Rules) (State, error) {
 			return State{}, err
 		}
 
-		(*struct {
-			_     [256]int32
-			Group *int64
-		})(unsafe.Pointer(&sm[0])).Group = noMatchingRules
+		setDefaultGroup(sm)
 
 		groups[n] = sm.GetState(nil)
 	}
 
 	return State{groups}, nil
+}
+
+func setDefaultGroup(sm group.StateMachine[int64]) {
+	(*struct {
+		_     [256]int32
+		Group *int64
+	})(unsafe.Pointer(&sm[0])).Group = noMatchingRules
 }
 
 func (s State) GetStateString(match string) State {
@@ -373,6 +377,73 @@ func (r *RuleTree) Iter() iter.Seq2[string, *RuleTree] {
 	return maps.All(r.children)
 }
 
+func (r *RuleTree) BuildRules() []Rules {
+	rules, _ := r.buildRules("/", []Rules{nil}, 0)
+
+	return rules
+}
+
+func (r *RuleTree) buildRules(path string, rules []Rules, wildcard int64) ([]Rules, bool) { //nolint:gocyclo,cyclop,funlen
+	var hasVeryComplex bool
+
+	for part, child := range r.children {
+		var childHasVeryComplex bool
+
+		rules, childHasVeryComplex = child.buildRules(path+part, rules, wildcard)
+		if childHasVeryComplex {
+			hasVeryComplex = true
+		}
+	}
+
+	if !hasVeryComplex {
+		for match := range r.Rules {
+			if strings.Count(match, "*") > 1 {
+				hasVeryComplex = true
+
+				break
+			}
+		}
+	}
+
+	for match, rule := range orderRulesByPrecedence(r.Rules) {
+		if hasVeryComplex {
+			rules = append(rules, addRuleToList(nil, path+match, rule.ID()))
+		} else {
+			rules[0] = addRuleToList(rules[0], path+match, rule.ID())
+		}
+	}
+
+	return rules, hasVeryComplex
+}
+
+func (r *RuleTree) addRuleStates(path string, rules Rules, wildcard int64) Rules {
+	if wc, ok := r.Rules["*"]; ok {
+		wildcard = wc.ID()
+	}
+
+	for part, child := range r.children {
+		rules = child.addRuleStates(path+part, rules, wildcard)
+	}
+
+	switch rs := getRuleState(r.Rules); rs {
+	case noRules:
+		rules = addNoRuleRules(rules, path, r.Dir, wildcard)
+	case SimpleWildcard:
+		rules = addSimpleWildcardRules(rules, path, r.Dir, wildcard)
+	case SimplePaths:
+		rules = addRuleToList(rules, path, processRules)
+	case SimpleWildcard | SimplePaths:
+		rules = addSimpleRules(rules, path, r.Dir, wildcard)
+	case ComplexWildcardWithPrefix, ComplexWildcardWithSuffix,
+		ComplexWildcardWithPrefix | SimplePaths, ComplexWildcardWithSuffix | SimplePaths:
+		rules = addComplexRules(rules, path, r.Dir, rs, wildcard, r.Rules)
+	default:
+		rules = addComplexWithWildcardRules(rules, path, r.Dir, rs, wildcard, r.Rules)
+	}
+
+	return rules
+}
+
 var basicWildcard = map[string]*db.Rule{"*": {Match: "*"}} //nolint:gochecknoglobals
 
 func buildDirRules(mount string, paths []string,
@@ -395,62 +466,10 @@ func buildDirRules(mount string, paths []string,
 
 	root.Canon()
 
-	rules, _ := buildRules(root, "/", []Rules{nil}, 0)
+	rules := root.BuildRules()
+	rules[0] = root.addRuleStates("/", rules[0], 0)
 
 	return rules, buildWildcards(root, "/", nil)
-}
-
-func buildRules(d *RuleTree, path string, rules []Rules, wildcard int64) ([]Rules, bool) { //nolint:gocyclo,cyclop,funlen
-	var hasVeryComplex bool
-
-	if wc, ok := d.Rules["*"]; ok {
-		wildcard = wc.ID()
-	}
-
-	for part, child := range d.children {
-		var childHasVeryComplex bool
-
-		rules, childHasVeryComplex = buildRules(child, path+part, rules, wildcard)
-		if childHasVeryComplex {
-			hasVeryComplex = true
-		}
-	}
-
-	if !hasVeryComplex {
-		for match := range d.Rules {
-			if strings.Count(match, "*") > 1 {
-				hasVeryComplex = true
-
-				break
-			}
-		}
-	}
-
-	switch rs := getRuleState(d.Rules); rs {
-	case noRules:
-		rules[0] = addNoRuleRules(rules[0], path, d.Dir, wildcard)
-	case SimpleWildcard:
-		rules[0] = addSimpleWildcardRules(rules[0], path, d.Dir, wildcard)
-	case SimplePaths:
-		rules[0] = addRuleToList(rules[0], path, processRules)
-	case SimpleWildcard | SimplePaths:
-		rules[0] = addSimpleRules(rules[0], path, d.Dir, wildcard)
-	case ComplexWildcardWithPrefix, ComplexWildcardWithSuffix,
-		ComplexWildcardWithPrefix | SimplePaths, ComplexWildcardWithSuffix | SimplePaths:
-		rules[0] = addComplexRules(rules[0], path, d.Dir, rs, wildcard, d.Rules)
-	default:
-		rules[0] = addComplexWithWildcardRules(rules[0], path, d.Dir, rs, wildcard, d.Rules)
-	}
-
-	for match, rule := range orderRulesByPrecedence(d.Rules) {
-		if hasVeryComplex {
-			rules = append(rules, addRuleToList(nil, path+match, rule.ID()))
-		} else {
-			rules[0] = addRuleToList(rules[0], path+match, rule.ID())
-		}
-	}
-
-	return rules, hasVeryComplex
 }
 
 func orderRulesByPrecedence(rules map[string]*db.Rule) iter.Seq2[string, *db.Rule] {

--- a/ruletree/statemachine.go
+++ b/ruletree/statemachine.go
@@ -6,12 +6,61 @@ import (
 	"math"
 	"slices"
 	"strings"
+	"unsafe"
 
 	"github.com/wtsi-hgi/backup-plans/db"
 	"github.com/wtsi-hgi/wrstat-ui/summary/group"
 )
 
 const processRules int64 = math.MinInt64
+
+var noMatchingRules = new(int64)
+
+type State struct {
+	groups []group.State[int64]
+}
+
+func BuildMultiStateMachine(rules []Rules) (State, error) {
+	groups := make([]group.State[int64], len(rules))
+
+	for n, rs := range rules {
+		sm, err := group.NewStatemachine(rs)
+		if err != nil {
+			return State{}, err
+		}
+
+		(*struct {
+			_     [256]int32
+			Group *int64
+		})(unsafe.Pointer(&sm[0])).Group = noMatchingRules
+
+		groups[n] = sm.GetState(nil)
+	}
+
+	return State{groups}, nil
+}
+
+func (s State) GetStateString(match string) State {
+	gs := make([]group.State[int64], 0, len(s.groups))
+
+	for _, g := range s.groups {
+		if rs := g.GetStateString(match); rs.GetGroup() != noMatchingRules {
+			gs = append(gs, rs)
+		}
+	}
+
+	return State{groups: gs}
+}
+
+func (s State) GetGroup() *int64 {
+	for _, g := range s.groups {
+		if r := g.GetGroup(); r != noMatchingRules && r != nil {
+			return r
+		}
+	}
+
+	return nil
+}
 
 // Rules is a list of rule paths and IDs ready to be compiled into a
 // StateMachine.
@@ -38,17 +87,17 @@ const (
 )
 
 func generateStatemachineFor(mount string, paths []string,
-	directoryRules map[string]*DirRules) (group.StateMachine[int64], group.StateMachine[int64], error) {
+	directoryRules map[string]*DirRules) (State, group.StateMachine[int64], error) {
 	rules, wildcards := buildDirRules(mount, paths, directoryRules)
 
-	sm, err := group.NewStatemachine(rules)
+	sm, err := BuildMultiStateMachine(rules)
 	if err != nil {
-		return nil, nil, err
+		return State{}, nil, err
 	}
 
 	wcs, err := group.NewStatemachine(wildcards)
 	if err != nil {
-		return nil, nil, err
+		return State{}, nil, err
 	}
 
 	return sm, wcs, nil
@@ -327,7 +376,7 @@ func (r *RuleTree) Iter() iter.Seq2[string, *RuleTree] {
 var basicWildcard = map[string]*db.Rule{"*": {Match: "*"}} //nolint:gochecknoglobals
 
 func buildDirRules(mount string, paths []string,
-	directoryRules map[string]*DirRules) (Rules, Rules) {
+	directoryRules map[string]*DirRules) ([]Rules, Rules) {
 	dirs := slices.Collect(maps.Keys(directoryRules))
 
 	slices.Sort(dirs)
@@ -346,41 +395,105 @@ func buildDirRules(mount string, paths []string,
 
 	root.Canon()
 
-	return buildRules(root, "/", nil, 0), buildWildcards(root, "/", nil)
+	rules, _ := buildRules(root, "/", []Rules{nil}, 0)
+
+	return rules, buildWildcards(root, "/", nil)
 }
 
-func buildRules(d *RuleTree, path string, rules Rules, wildcard int64) Rules { //nolint:gocyclo,cyclop,funlen
-	if len(d.Rules) > 0 {
-		if wc, ok := d.Rules["*"]; ok {
-			wildcard = wc.ID()
-		}
+func buildRules(d *RuleTree, path string, rules []Rules, wildcard int64) ([]Rules, bool) { //nolint:gocyclo,cyclop,funlen
+	var hasVeryComplex bool
 
-		for match, rule := range d.Rules {
-			rules = addRuleToList(rules, path+match, rule.ID())
+	if wc, ok := d.Rules["*"]; ok {
+		wildcard = wc.ID()
+	}
+
+	for part, child := range d.children {
+		var childHasVeryComplex bool
+
+		rules, childHasVeryComplex = buildRules(child, path+part, rules, wildcard)
+		if childHasVeryComplex {
+			hasVeryComplex = true
+		}
+	}
+
+	if !hasVeryComplex {
+		for match := range d.Rules {
+			if strings.Count(match, "*") > 1 {
+				hasVeryComplex = true
+
+				break
+			}
 		}
 	}
 
 	switch rs := getRuleState(d.Rules); rs {
 	case noRules:
-		rules = addNoRuleRules(rules, path, d.Dir, wildcard)
+		rules[0] = addNoRuleRules(rules[0], path, d.Dir, wildcard)
 	case SimpleWildcard:
-		rules = addSimpleWildcardRules(rules, path, d.Dir, wildcard)
+		rules[0] = addSimpleWildcardRules(rules[0], path, d.Dir, wildcard)
 	case SimplePaths:
-		rules = addRuleToList(rules, path, processRules)
+		rules[0] = addRuleToList(rules[0], path, processRules)
 	case SimpleWildcard | SimplePaths:
-		rules = addSimpleRules(rules, path, d.Dir, wildcard)
+		rules[0] = addSimpleRules(rules[0], path, d.Dir, wildcard)
 	case ComplexWildcardWithPrefix, ComplexWildcardWithSuffix,
 		ComplexWildcardWithPrefix | SimplePaths, ComplexWildcardWithSuffix | SimplePaths:
-		rules = addComplexRules(rules, path, d.Dir, rs, wildcard, d.Rules)
+		rules[0] = addComplexRules(rules[0], path, d.Dir, rs, wildcard, d.Rules)
 	default:
-		rules = addComplexWithWildcardRules(rules, path, d.Dir, rs, wildcard, d.Rules)
+		rules[0] = addComplexWithWildcardRules(rules[0], path, d.Dir, rs, wildcard, d.Rules)
 	}
 
-	for part, child := range d.children {
-		rules = buildRules(child, path+part, rules, wildcard)
+	for match, rule := range orderRulesByPrecedence(d.Rules) {
+		if hasVeryComplex {
+			rules = append(rules, addRuleToList(nil, path+match, rule.ID()))
+		} else {
+			rules[0] = addRuleToList(rules[0], path+match, rule.ID())
+		}
 	}
 
-	return rules
+	return rules, hasVeryComplex
+}
+
+func orderRulesByPrecedence(rules map[string]*db.Rule) iter.Seq2[string, *db.Rule] {
+	return func(yield func(string, *db.Rule) bool) {
+		keys := slices.Collect(maps.Keys(rules))
+
+		slices.SortFunc(keys, matchPrecedence)
+
+		for _, key := range keys {
+			if !yield(key, rules[key]) {
+				return
+			}
+		}
+	}
+}
+
+func matchPrecedence(a, b string) int {
+	if len(a) == 0 {
+		if len(b) == 0 {
+			return 0
+		}
+
+		return 1
+	} else if len(b) == 0 {
+		return -1
+	}
+
+	aPos := strings.IndexByte(a, '*')
+	bPos := strings.IndexByte(b, '*')
+
+	if aPos == -1 {
+		if bPos == -1 {
+			return len(b) - len(a)
+		}
+
+		return -1
+	} else if bPos == -1 {
+		return 1
+	} else if a[:aPos] == b[:bPos] {
+		return matchPrecedence(a[aPos+1:], b[bPos+1:])
+	}
+
+	return bPos - aPos
 }
 
 func getRuleState(rules map[string]*db.Rule) ruleState { //nolint:gocognit

--- a/ruletree/statemachine.go
+++ b/ruletree/statemachine.go
@@ -27,7 +27,7 @@ type State struct {
 // BuildMultiStateMachine take a slice of rulesets and builds a statemachine for
 // each.
 //
-// State returns handles like group.State, but iterates over each individual
+// Returned State handles like group.State, but iterates over each individual
 // StateMachine, removing those that no longer apply.
 //
 // The slice should be ordered by precedence, with the highest first.

--- a/ruletree/statemachine.go
+++ b/ruletree/statemachine.go
@@ -396,37 +396,62 @@ func (r *RuleTree) BuildRules() []Rules {
 	return rules
 }
 
-func (r *RuleTree) buildRules(path string, rules []Rules) ([]Rules, bool) { //nolint:gocyclo,gocognit
-	var hasVeryComplex bool
+func (r *RuleTree) buildRules(path string, rules []Rules) ([]Rules, bool) {
+	var childHasVeryComplex bool
+
+	rules, childHasVeryComplex = r.buildChildRules(path, rules)
+	hasVeryComplex := r.hasComplexRules()
+	rules = r.processRules(path, rules, hasVeryComplex, childHasVeryComplex)
+
+	return rules, hasVeryComplex || childHasVeryComplex
+}
+
+func (r *RuleTree) buildChildRules(path string, rules []Rules) ([]Rules, bool) {
+	var childHasVeryComplex bool
 
 	for part, child := range r.children {
-		var childHasVeryComplex bool
+		var complexChild bool
 
-		rules, childHasVeryComplex = child.buildRules(path+part, rules)
-		if childHasVeryComplex {
-			hasVeryComplex = true
+		rules, complexChild = child.buildRules(path+part, rules)
+		if complexChild {
+			childHasVeryComplex = true
 		}
 	}
 
-	if !hasVeryComplex {
-		for match := range r.Rules {
-			if strings.Count(match, "*") > 1 {
-				hasVeryComplex = true
+	return rules, childHasVeryComplex
+}
 
-				break
-			}
+func (r *RuleTree) hasComplexRules() bool {
+	for match := range r.Rules {
+		if strings.Count(match, "*") > 1 {
+			return true
 		}
+	}
+
+	return false
+}
+
+func (r *RuleTree) processRules(path string, rules []Rules, hasVeryComplex, childHasVeryComplex bool) []Rules {
+	if len(r.Rules) == 0 {
+		return rules
+	}
+
+	var idx int
+
+	if childHasVeryComplex && !hasVeryComplex {
+		idx = len(rules)
+		rules = append(rules, nil)
 	}
 
 	for match, rule := range orderRulesByPrecedence(r.Rules) {
 		if hasVeryComplex {
 			rules = append(rules, addRuleToList(nil, path+match, rule.ID()))
 		} else {
-			rules[0] = addRuleToList(rules[0], path+match, rule.ID())
+			rules[idx] = addRuleToList(rules[idx], path+match, rule.ID())
 		}
 	}
 
-	return rules, hasVeryComplex
+	return rules
 }
 
 func (r *RuleTree) addRuleStates(path string, rules Rules, wildcard int64) Rules { //nolint:gocyclo


### PR DESCRIPTION
Split statemachine by (very) complex (multi-wildcard) rules so that factorial RAM usage doesn't become an issue.

On a full ruleset calculation take roughly the same amount of time, but for orders of magnitude less RAM used by the statemachines (it's now a rounding error in the RAM usage).